### PR TITLE
Refactor: 將首頁邏輯移至 HomePage 元件並更新樣式

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,46 +1,88 @@
 <script setup>
-import {useTabStore} from "@/store/tab.js";
-import {onMounted, ref} from "vue";
-import {storeToRefs} from "pinia";
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { storeToRefs } from "pinia";
+import { useTabStore } from "@/store/tab.js";
 import Sponsor from "@/components/Sponsor.vue";
+import dragonArtifact_image from "@/assets/dragonArtifact/傳說神笏.png";
+import HomePage from "@/components/HomePage.vue";
 
+const router = useRouter();
 const tabStore = useTabStore();
-const {currentTab, currentSideBarTab, screenWidth} = storeToRefs(tabStore);
-const showSmNavBarTab = ref(false);
+const { currentTab, currentSideBarTab, screenWidth, showSmNavBarTab } = storeToRefs(tabStore);
+
 const isSponsorModalVisible = ref(false);
+
+const getImageUrl = (url) => {
+  return new URL(`/src/assets/${url}`, import.meta.url).href;
+};
+
+
+const RouteTabs = [
+  { name: '龍神器', path: '/dragon-artifact' },
+  { name: '傳說裝備', path: '/legendary-equipment' },
+  { name: '英雄裝備', path: '/epic-equipment' },
+  { name: '體質', path: '/constitution' },
+  { name: '奇緣', path: '/mystery' },
+  { name: '地圖資源', path: '/resource' },
+  { name: '委託', path: '/requests' },
+  { name: '一些小功能', path: '/other-calculate' },
+  { name: '更新日誌', path: '/change-log' },
+];
+
+const leftRouteTabs = [
+  { name: '龍神器', path: '/dragon-artifact' },
+  { name: '傳說裝備', path: '/legendary-equipment' },
+  { name: '英雄裝備', path: '/epic-equipment' },
+  { name: '體質', path: '/constitution' },
+  { name: '奇緣', path: '/mystery' },
+  { name: '地圖資源', path: '/resource' },
+  { name: '委託', path: '/requests' },
+  { name: '一些小功能', path: '/other-calculate' }
+];
+
+const rightRouteTabs = [
+  { name: '更新日誌', path: '/change-log' },
+];
+
+const keepAliveComponentList = ['DragonArtifact', 'EpicEquipment', 'LegendaryEquipment'];
+
 const updateScreenWidth = () => {
   screenWidth.value = window.innerWidth;
 };
 
 
+
+
+const isActiveRoute = (routePath) => {
+  return currentTab.value === routePath;
+};
+
 onMounted(() => {
   updateScreenWidth();
   window.addEventListener('resize', updateScreenWidth);
-});
 
+  // Router beforeEach guard
+  router.beforeEach((to, from, next) => {
+    if (to.path === '/') {
+      return;
+    }
+    currentTab.value = to.path.match(/^\/[^\/]+/)[0];
+    next();
+  });
+});
 </script>
+
 
 <template>
   <main>
-    <div class="welcome-container" v-if="!currentTab">
-      <div class="page-options" >
-        <router-link
-          v-for="route in RouteTabs"
-          :key="route.name"
-          :to="route.path"
-          :class="['page-option', route.path.replace(/^\//, '')]"
-          @click="currentTab = route.path; showSmNavBarTab = false"
-        >
-        {{ route.name }}
-        </router-link>
-      </div>
-    </div>
+    <HomePage/>
     <div class="demo" v-if="currentTab">
       <div class="nav nav-tabs" v-if="screenWidth > 849 ">
         <ul class="leftTab-container">
-          <li v-for="route in leftRouteTabs" :key="route.name" class="nav-item" @click="currentTab = route.path">
-            <router-link :to="route.path" :class="{'nav-link': true, 'active': isActiveRoute(route.path)}">
-              {{ route.name }}
+          <li v-for="targetRoute in leftRouteTabs" :key="targetRoute.name" class="nav-item" @click="currentTab = targetRoute.path">
+            <router-link :to="targetRoute.path" :class="{'nav-link': true, 'active': isActiveRoute(targetRoute.path)}">
+              {{ targetRoute.name }}
             </router-link>
           </li>
         </ul>
@@ -65,7 +107,8 @@ onMounted(() => {
         </ul>
       </div>
       <div class="sm-nav-bar" v-else>
-        <div class="current-page" @click="showSmNavBarTab = !showSmNavBarTab" v-if="RouteTabs.find(route => route.path === currentTab) !== undefined">
+        <div class="current-page" @click="showSmNavBarTab = !showSmNavBarTab"
+             v-if="RouteTabs.find(route => route.path === currentTab) !== undefined">
           {{ RouteTabs.find(route => route.path === currentTab).name }}
         </div>
         <div class="sm-nav-bar-tab" v-if="showSmNavBarTab">
@@ -89,68 +132,9 @@ onMounted(() => {
         </keep-alive>
       </router-view>
     </div>
-    <Sponsor :visible="isSponsorModalVisible" @close="isSponsorModalVisible = false" />
+    <Sponsor :visible="isSponsorModalVisible" @close="isSponsorModalVisible = false"/>
   </main>
 </template>
-
-<script>
-
-import {useTabStore} from "@/store/tab.js";
-
-export default {
-  name: "App",
-  data() {
-    return {
-      RouteTabs: [
-        {name: '龍神器', path: '/dragon-artifact'},
-        {name: '傳說裝備', path: '/legendary-equipment'},
-        {name: '英雄裝備', path: '/epic-equipment'},
-        {name: '體質', path: '/constitution'},
-        {name: '奇緣', path: '/mystery'},
-        {name: '地圖資源', path: '/resource'},
-        {name: '委託', path: '/requests'},
-        {name: '一些小功能', path: '/other-calculate'},
-        {name: '更新日誌', path: '/change-log'},
-      ],
-      leftRouteTabs: [
-        {name: '龍神器', path: '/dragon-artifact'},
-        {name: '傳說裝備', path: '/legendary-equipment'},
-        {name: '英雄裝備', path: '/epic-equipment'},
-        {name: '體質', path: '/constitution'},
-        {name: '奇緣', path: '/mystery'},
-        {name: '地圖資源', path: '/resource'},
-        {name: '委託', path: '/requests'},
-        {name: '一些小功能', path: '/other-calculate'}
-      ],
-      rightRouteTabs: [
-        {name: '更新日誌', path: '/change-log'},
-      ],
-      keepAliveComponentList: ['DragonArtifact', 'EpicEquipment', 'LegendaryEquipment']
-    };
-  },
-  computed: {},
-  created() {
-    const tabStore = useTabStore();
-    this.$router.beforeEach((to, from, next) => {
-      if (to.path === '/') {
-        return;
-      }
-      tabStore.currentTab = to.path.match(/^\/[^\/]+/)[0];
-      next();
-    });
-  },
-  methods: {
-    getImageUrl(url) {
-      return new URL(`/src/assets/${url}`, import.meta.url).href;
-    },
-    isActiveRoute(routePath) {
-      const tabStore = useTabStore();
-      return tabStore.currentTab === routePath;
-    },
-  },
-};
-</script>
-
 
 <style scoped lang="scss">
 .sponsor-logo {

--- a/src/assets/all.scss
+++ b/src/assets/all.scss
@@ -24,21 +24,21 @@ body {
 }
 
 .page-options {
+
   display: flex;
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
   height: 100%;
-  width: 100%;
-  padding: 5rem 10rem;
   background-image: url("../assets/bg/bggg.png");
   background-repeat: no-repeat;
-  background-size: 100% 100%;
-
+  background-size: cover;
   animation: fadeIn 0.5s ease-in-out;
-  animation-fill-mode: forwards; /* 動畫結束後保持最後的狀態 */
+  animation-fill-mode: forwards;
+  gap: 2rem;
   opacity: 0; /* 初始透明度為 0 */
   z-index: -1;
+  overflow: auto;
 
   @media (max-width: 1024px) {
     padding: 5rem 5rem;
@@ -48,32 +48,35 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 200px;
-    height: 200px;
+    width: 50px;
+    height: 20rem;
     justify-content: center;
     border: 1px solid #22303C;
     box-shadow: 0 1px 10px 0 #7594b7;
-    border-radius: 5px;
+    border-radius: 50px;
     background-color: #22303C;
     background-image: url("../assets/bg/bggg.png");
     opacity: 0.7;
     margin: 1rem;
-    font-size: 1.5rem;
+    writing-mode: vertical-rl;
+    font-size: 1.4rem;
     color: #eeeef4;
     cursor: pointer;
 
     @media (max-width: 1024px) {
-        width: 100px;
-        min-width: 100px;
-        height: 100px;
-        font-size: 1rem;
+        //width: 100px;
+        //min-width: 100px;
+        font-size: 1.2rem;
+        height: 15rem;
+        //font-size: 1rem;
     }
 
     @media (max-width: 425px) {
-      width: 60px;
-      min-width: 60px;
-      height: 60px;
-      font-size: .7rem;
+      //width: 60px;
+      //min-width: 60px;
+      font-size: 0.5rem;
+      height: 10rem;
+      //font-size: .7rem;
     }
 
   }
@@ -82,7 +85,7 @@ body {
     transform: scale(1.05);
     transition: all 0.2s ease-in-out;
     background-color: #192734;
-
+    box-shadow: 0 1px 20px 8px #7594b7;
   }
 }
 

--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -1,0 +1,156 @@
+<script setup>
+
+
+import {useTabStore} from "@/store/tab.js";
+import {storeToRefs} from "pinia";
+
+import {useRouter} from "vue-router";
+import {ref} from "vue";
+
+const router = useRouter();
+const tabStore = useTabStore();
+const { currentTab, currentSideBarTab, screenWidth, showSmNavBarTab } = storeToRefs(tabStore);
+
+const RouteTabs = [
+  { name: '龍神器', path: '/dragon-artifact', image: null },
+  { name: '傳說裝備', path: '/legendary-equipment', image: null },
+  { name: '英雄裝備', path: '/epic-equipment', image: null },
+  { name: '體質', path: '/constitution', image: null },
+  { name: '奇緣', path: '/mystery', image: null },
+  { name: '地圖資源', path: '/resource', image: null },
+  { name: '委託', path: '/requests', image: null },
+  { name: '一些小功能', path: '/other-calculate', image: null },
+  { name: '更新日誌', path: '/change-log', image: null },
+];
+
+const getFullImageUrl = (path) => {
+  // 如果已經是完整 URL 就直接返回
+  if (path.startsWith('http') || path.startsWith('/assets')) {
+    return path;
+  }
+  // 否則使用 new URL 處理
+  return new URL(path, import.meta.url).href;
+};
+
+const directToPage = (targetRoute) => {
+  currentTab.value = targetRoute.path;
+  showSmNavBarTab.value = false;
+  router.push(targetRoute.path);
+};
+
+</script>
+
+<template>
+    <div class="welcome-container" v-if="!currentTab">
+      <div class="page-options">
+        <template
+            v-for="targetRoute in RouteTabs"
+            :key="targetRoute.name"
+        >
+          <div :class="['page-option', targetRoute.path.replace(/^\//, '')]"
+               @click="directToPage(targetRoute)">
+            <div class="page-option-text">
+              {{ targetRoute.name }}
+            </div>
+            <img class="page-option-image" :src="targetRoute.image" alt="">
+          </div>
+        </template>
+      </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.welcome-container {
+  height: 100vh;
+  width: 100vw;
+}
+
+.page-options {
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  height: 100%;
+  background-image: url("../assets/bg/bggg.png");
+  background-repeat: no-repeat;
+  background-size: cover;
+  animation: fadeIn 0.5s ease-in-out;
+  animation-fill-mode: forwards;
+  gap: 2rem;
+  opacity: 0; /* 初始透明度為 0 */
+  z-index: -1;
+  overflow: auto;
+
+  @media (max-width: 1024px) {
+    padding: 5rem 5rem;
+  }
+
+  .page-option {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+    width: 50px;
+    height: 20rem;
+    justify-content: center;
+    border: 1px solid #22303C;
+    box-shadow: 0 1px 10px 0 #7594b7;
+    border-radius: 50px;
+    background-color: #22303C;
+    background-image: url("../assets/bg/bggg.png");
+    opacity: 0.7;
+    margin: 1rem;
+    writing-mode: vertical-rl;
+    font-size: 1.4rem;
+    color: #eeeef4;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    @media (max-width: 1024px) {
+        font-size: 1.2rem;
+        height: 15rem;
+    }
+
+    @media (max-width: 425px) {
+      font-size: 1rem;
+      height: 10rem;
+    }
+
+    .page-option-text,
+    .page-option-image {
+      pointer-events: none;
+    }
+
+    .page-option-text{
+      letter-spacing: 3px;
+    }
+
+    .page-option-image {
+      width: 100%;
+      height: auto;
+      max-height: 80%;
+      max-width: 80%;
+      object-fit: contain; // 保持圖片比例
+
+      @media (max-width: 1024px) {
+        max-height: 70%;
+        max-width: 70%;
+      }
+
+      @media (max-width: 425px) {
+        max-height: 50%;
+        max-width: 50%;
+      }
+    }
+  }
+
+  .page-option:hover {
+    transform: scale(1.05);
+    transition: all 0.2s ease-in-out;
+    background-color: #192734;
+    box-shadow: 0 1px 20px 8px #7594b7;
+  }
+}
+
+</style>

--- a/src/store/tab.js
+++ b/src/store/tab.js
@@ -5,6 +5,7 @@ export const useTabStore = defineStore('tab', {
     currentTab: "",
     currentSideBarTab: "",
     screenWidth: 0,
+    showSmNavBarTab: false,
   }),
   actions: {
   },


### PR DESCRIPTION
Refactor: 將首頁邏輯移至 HomePage 元件並更新樣式

- 重構 `App.vue`，移除路由分頁與首頁邏輯的直接處理。
- 實作 `HomePage.vue` 以顯示導航選項。
- 更新 `src/assets/all.scss` 與 `HomePage.vue` 的樣式，改善響應式設計與頁面選項的視覺效果。
- 在 `tab.js` store 中新增 `showSmNavBarTab` 狀態。